### PR TITLE
feat: add type prop to BaseIconButton

### DIFF
--- a/src/BaseIconButton.tsx
+++ b/src/BaseIconButton.tsx
@@ -26,6 +26,7 @@ interface Props {
   hasAvatar?: boolean;
   enabled?: boolean;
   component?: "span" | "button";
+  type?: "button" | "submit";
 }
 
 export const BaseIconButton = (props: Props): ReactElement => {
@@ -75,6 +76,7 @@ export const BaseIconButton = (props: Props): ReactElement => {
           </Button>
         ) : (
           <IconButton
+            type={props.type}
             ref={(ref) => {
               if (!ref || !props.setRefCallback) return;
               props.setRefCallback(ref);
@@ -110,4 +112,5 @@ BaseIconButton.defaultProps = {
   enabled: true,
   fill: false,
   component: "button",
+  type: "button",
 };


### PR DESCRIPTION
## Description

Add `type` to the BaseIconButton component. This allows us to pass in "submit"  as a prop from the search button in CURATE.


## Dependency changes

N/A

## Testing

N/A

## Documentation

N/A

## Migrations (if applicable)
N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
