### PR TITLE
fix: hack in support for makeStyles in package

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -20,7 +20,7 @@ jobs:
         run: npx percy snapshot ./dist
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          
+
   Lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -81,6 +81,10 @@ jobs:
         run: npm i --omit=peer
       - name: Build
         run: npm run build
+      - name: TEMP - force global and scoped styles
+        run: |
+          awk '{gsub("productionPrefix = \"jss\",","productionPrefix = \"style\",")}1' dist/index.es.js > tmp && mv -f tmp dist/index.es.js
+          awk '{gsub("disableGlobal = false,","disableGlobal = true,")}1' dist/index.es.js > tmp && mv -f tmp dist/index.es.js
       - name: Publish
         uses: mikeal/merge-release@master
         env:

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -28,6 +28,7 @@ declare module "@mui/styles/defaultTheme" {
   interface DefaultTheme extends Theme {}
 }
 
+
 export const imgSrc = (src: string, type = "svg"): string =>
   new URL(`/src/assets/${src}.${type}`, import.meta.url).href;
 

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -20,7 +20,10 @@ export default defineConfig({
         "react-router-dom",
         "@mui/material",
         "@mui/icons-material",
-        "@mui/lab"
+        "@mui/styles",
+        "@mui/system",
+        "@emotion/react",
+        "@emotion/styled"
       ],
       output: {
         // Provide global variables to use in the UMD build


### PR DESCRIPTION
As a temp fix to allow us to to use makeStyles in parent repos, hardcode the CSS prefix to "style" rather than the generic JSS. It doesn't seem to be exposed in code so it's smashed into the final package with bash!