### PR TITLE
fix: set BasePopover paper borderRadius to 9px

### DIFF
--- a/src/BasePopover.tsx
+++ b/src/BasePopover.tsx
@@ -9,6 +9,7 @@ const useStyle = makeStyles(() => ({
     justifyContent: "center",
     alignItems: "center",
     backgroundColor: "transparent",
+    borderRadius: "9px",
   },
 }));
 


### PR DESCRIPTION
## Description

The weird corners issue was affecting `LabelsPopover` as well as `DefaultLabelsDialog`; this PR fixes the issue in the former. I tried to add `borderRadius` as a prop rather than hard-coding it, but couldn't make it work so I left it hard-coded for now since we're deprecating `makeStyles` anyway.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
