### PR TITLE
fix: Keep popover onclick

### DIFF
--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -53,10 +53,10 @@ export function Dialog({
 
   return (
     <>
-      {cloneElement(TriggerButton as any, {
+      {cloneElement(TriggerButton, {
         onClick: () => {
           handleClick();
-          TriggerButton.props.onClick();
+          (TriggerButton.props as { onClick: () => void }).onClick();
         },
       })}
       <MaterialDialog open={open} onClose={handleClose}>

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -50,10 +50,14 @@ export function Dialog({
       {children}
     </Card>
   );
+
   return (
     <>
       {cloneElement(TriggerButton as any, {
-        onClick: handleClick,
+        onClick: () => {
+          handleClick();
+          TriggerButton.props.onClick();
+        },
       })}
       <MaterialDialog open={open} onClose={handleClose}>
         {dialogContent}

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -41,10 +41,10 @@ export function Popover({
   );
   return (
     <>
-      {cloneElement(TriggerButton as any, {
+      {cloneElement(TriggerButton, {
         onClick: (event: MouseEvent<HTMLButtonElement>) => {
           handleClick(event);
-          TriggerButton.props.onClick();
+          (TriggerButton.props as { onClick: () => void }).onClick();
         },
         fill: Boolean(anchorEl),
       })}

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -42,7 +42,10 @@ export function Popover({
   return (
     <>
       {cloneElement(TriggerButton as any, {
-        onClick: handleClick,
+        onClick: (event: MouseEvent<HTMLButtonElement>) => {
+          handleClick(event);
+          TriggerButton.props.onClick();
+        },
         fill: Boolean(anchorEl),
       })}
       <MaterialPopover


### PR DESCRIPTION
## Description

The `Popover` and `Dialog` components both require a button element to be passed as `TriggerButton`, but they override the button's `onClick` to call `handleClick()`. This means you can't use `onClick` to do something when the button is clicked. This PR still overrides `onClick`, but the new `onClick` calls `handleClick()` and then runs the original `onClick`, instead of just calling `handleClick`. This will fix a bug in ANNOTATE where the background toolbox never closes in readonly mode, and a bug in CURATE where the default labels dialog clears itself when you hit Cancel, instead of returning to the state it was in when opened.

Edit: also removed the `as any` qualifier on `TriggerButton` because it was causing a lint warning and didn't seem to be necessary for any typescript reasons, @ChrisBaidoo please revert that if it's necessary for some reason I couldn't see.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
