### PR TITLE
feat: add the ability to id dialogues and cards

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,12 +1,6 @@
 import { ReactElement } from "react";
 
-import {
-  Card as MaterialCard,
-  Paper,
-  Typography,
-  styled,
-
-} from "@mui/material";
+import { Card as MaterialCard, Paper, Typography, styled } from "@mui/material";
 import SVG from "react-inlinesvg";
 import { theme } from "../../theme";
 import { icons } from "../../icons";
@@ -21,6 +15,7 @@ interface Props {
   warningDialog?: boolean;
   isPinned?: boolean | null;
   handlePin?: () => void;
+  id?: string | null;
 }
 
 const CardIconButton = styled(IconButton)({
@@ -38,6 +33,15 @@ const CardIconButton = styled(IconButton)({
 });
 
 export function Card(props: Props): JSX.Element {
+  let id: string;
+  if (props.id === null || props.id === undefined) {
+    id = Math.random()
+      .toString(36)
+      .replace(/[^a-z]+/g, "")
+      .substr(0, 5);
+  } else {
+    id = props.id;
+  }
   return (
     <MaterialCard sx={{ borderRadius: "8px" }}>
       <Paper
@@ -56,7 +60,7 @@ export function Card(props: Props): JSX.Element {
           "button:last-child": {
             marginRight: "-8px",
           },
-          border: `1px solid ${props.warningDialog ? "#9F6DEA":"#02E098"}`,
+          border: `1px solid ${props.warningDialog ? "#9F6DEA" : "#02E098"}`,
         }}
       >
         {props.warningDialog && (
@@ -82,6 +86,7 @@ export function Card(props: Props): JSX.Element {
             backgroundColor={props.isPinned ? "#FFFFFF" : "inherit"}
             tooltip={{ name: props.isPinned ? "Turn Off Pin" : "Pin Open" }}
             onClick={props.handlePin}
+            id={`${id}-dailog-pin`}
           />
         )}
         {props.closeButton && (
@@ -90,6 +95,7 @@ export function Card(props: Props): JSX.Element {
             tooltip={{ name: "Close" }}
             onClick={props.handleClose}
             iconColor={props.warningDialog ? "#FFFFFF" : "#000000"}
+            id={`${id}-dailog-close`}
           />
         )}
       </Paper>
@@ -115,4 +121,5 @@ Card.defaultProps = {
   warningDialog: null,
   isPinned: null,
   handlePin: null,
+  id: null,
 };

--- a/src/components/Dialog/Dialogue.tsx
+++ b/src/components/Dialog/Dialogue.tsx
@@ -11,17 +11,10 @@ interface Props {
   close?: boolean;
   afterClose?: () => void;
   buttons?: boolean;
+  id?: string | null;
 }
 
-export function Dialogue({
-  children,
-  title,
-  TriggerButton,
-  close,
-  warningDialog,
-  afterClose,
-  buttons,
-}: Props): ReactElement | null {
+export function Dialogue(props: Props): ReactElement | null {
   const [open, setOpen] = useState<boolean>(false);
 
   const handleClick = (): void => {
@@ -31,30 +24,31 @@ export function Dialogue({
   const handleClose = (): void => {
     setOpen(false);
     // Reset defaults when Dialogue is closed
-    if (afterClose) {
-      afterClose();
+    if (props.afterClose) {
+      props.afterClose();
     }
   };
 
   // externally close the Dialogue
   useEffect(() => {
-    if (close) {
+    if (props.close) {
       setOpen(false);
     }
-  }, [close]);
+  }, [props.close]);
 
   const dialogContent = (
     <>
       <Card
-        title={title}
+        title={props.title}
         handleClose={handleClose}
         closeButton
-        warningDialog={warningDialog}
+        warningDialog={props.warningDialog}
+        id={props.id}
       >
         <>
-          <Typography>{children}</Typography>
+          <Typography>{props.children}</Typography>
 
-          {buttons && (
+          {props.buttons && (
             <Box
               sx={{
                 display: "flex",
@@ -65,7 +59,7 @@ export function Dialogue({
               <Button text="Button" color="secondary" variant="outlined" />
               <Button
                 text="Button"
-                color={warningDialog ? "secondary" : "primary"}
+                color={props.warningDialog ? "secondary" : "primary"}
               />
             </Box>
           )}
@@ -76,10 +70,12 @@ export function Dialogue({
 
   return (
     <>
-      {cloneElement(TriggerButton, {
+      {cloneElement(props.TriggerButton, {
         onClick: () => {
           handleClick();
-          const { onClick } = TriggerButton.props as { onClick?: () => void };
+          const { onClick } = props.TriggerButton.props as {
+            onClick?: () => void;
+          };
           if (onClick) onClick();
         },
       })}
@@ -96,4 +92,5 @@ Dialogue.defaultProps = {
   afterClose: null,
   warningDialog: null,
   buttons: false,
+  id: null,
 };


### PR DESCRIPTION
## Description

As mentioned on Slack, I need a way to assign `id` tags for dialogue close buttons so that I can streamline our visual testing in MANAGE and elsewhere. This creates an optional `id` tag for our `<Dialogue/>` component, which is passed down to the child `<Card/>` and used to label both the close and pin buttons (a bit of future proofing). If the `<Card/>` gets an empty `id` it will generate a random string of 5 characters to prevent multiple occurrences of the same `id` in the DOM.

I also changed how `<Dialogue/>` handles props to match `<Card/>` - does this make sense or is there a reason to restructure like that?

## Checklist:

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
