### PR TITLE
feat: Custom text for confirm button of Dialogue

### DIFF
--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -90,7 +90,7 @@ const AdvancedDialogExample = (): ReactElement => {
       <AdvancedDialog
         title="Advanced Dialogue"
         open={open}
-        warningDialogue
+        warningDialog
         onClose={onClose}
         children={
           <Typography>
@@ -231,6 +231,20 @@ const rows = [
   { id: 12, lastName: "Stark", firstName: "Arya", age: 16 },
 ];
 
+const NotepadWrapper = (): ReactElement => {
+  const [notepadText, setNotepadText] = useState<string>("");
+  return (
+    <Notepad
+      value={notepadText}
+      onChange={(e) => {
+        setNotepadText(e.target.value);
+      }}
+      rows={5}
+      placeholder="Helper text"
+    />
+  );
+};
+
 const app = (
   <StylesProvider>
     <StyledEngineProvider injectFirst>
@@ -348,7 +362,7 @@ const app = (
 
           <br></br>
           <Box sx={{ width: "300px" }}>
-            <Card title={"Example Card"} warningDialogue>
+            <Card title={"Example Card"} warningDialog>
               <Typography>This is a warning card.</Typography>
             </Card>
           </Box>
@@ -470,10 +484,9 @@ const app = (
           <h2>Popper</h2>
           <ExamplePopper />
           <h2>Notepad</h2>
-          <div style={{ width: "300px" }}>
-            <Notepad rows={5} placeholder="Helper text" />
+          <div style={{ width: "500px" }}>
+            <NotepadWrapper />
           </div>
-
           <h2>Icons</h2>
           <section style={{ float: "left" }}>
             {Object.entries(icons).map(([name, src]) => (

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Theme styles for gliff.ai apps",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/src/index.d.ts",
   "files": [
     "dist"
   ],

--- a/src/WarningSnackbar.tsx
+++ b/src/WarningSnackbar.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { ReactElement, SyntheticEvent } from "react";
 import SVG from "react-inlinesvg";
 import {
   IconButton,
@@ -6,6 +6,7 @@ import {
   SnackbarContent,
   ThemeProvider,
   StyledEngineProvider,
+  SnackbarCloseReason,
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { theme } from "./theme";
@@ -43,7 +44,10 @@ const useStyle = makeStyles(() => ({
 
 interface Props {
   open: boolean;
-  onClose: () => void;
+  onClose: (
+    event?: Event | SyntheticEvent,
+    reason?: SnackbarCloseReason
+  ) => void;
   messageText: string | ReactElement;
 }
 

--- a/src/components/Dialogue/Dialogue.tsx
+++ b/src/components/Dialogue/Dialogue.tsx
@@ -11,6 +11,7 @@ import { Button } from "../Button/Button";
 import { white } from "../../theme";
 
 interface Props {
+  id?: string | null;
   children?: ReactElement | null;
   TriggerButton: JSX.Element;
   title: string;
@@ -18,11 +19,11 @@ interface Props {
   close?: boolean;
   afterOpen?: (() => void) | null;
   afterClose?: (() => void) | null;
-  id?: string | null;
   backgroundColor?: string;
-  onCancel?: (() => void) | null;
-  onConfirm?: ((event: MouseEvent) => void) | null;
   confirmEnabled?: boolean;
+  confirmText?: string;
+  onConfirm?: ((event: MouseEvent) => void) | null;
+  onCancel?: (() => void) | null;
 }
 
 export function Dialogue(props: Props): ReactElement | null {
@@ -84,7 +85,7 @@ export function Dialogue(props: Props): ReactElement | null {
                 }}
               />
               <Button
-                text="Confirm"
+                text={props.confirmText}
                 color={props.warningDialog ? "secondary" : "primary"}
                 onClick={(e) => {
                   props.onConfirm(e);
@@ -129,4 +130,5 @@ Dialogue.defaultProps = {
   onCancel: null,
   onConfirm: null,
   confirmEnabled: true,
+  confirmText: "Confirm",
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "examples/**/*.ts*",
     "src/**/**/*.ts*",
   ],
-  "exclude": ["src/**/**/*_.ts*","node_modules/**/*"]
+  "exclude": ["src/**/**/*_.ts*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,12 +18,8 @@
     "experimentalDecorators": true,
   },
   "include": [
-    "examples/src/**/*.tsx",
-    "src/**/*.tsx",
-    "src/**/*.ts",
-    "test/**/*.ts",
-    "typings/**/*.ts",
-    "./jest-setup.ts"
+    "examples/**/*.ts*",
+    "src/**/**/*.ts*",
   ],
-  "exclude": ["src/**/*_.tsx","node_modules/**/*"]
+  "exclude": ["src/**/**/*_.ts*","node_modules/**/*"]
 }


### PR DESCRIPTION
## Description
- add new optional prop `confirmText` to `Dialogue`, so we can change the text for the 'confirm' button.
- include `example` folder in the compiled files, so that `example/index.tsx` is type-checked, which should help with spotting any typing mismatches before re-using a component in other repos.
- fixed lint errors for `example/index.tsx`

required for gliff-ai/annotate/pull/775

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
