### PR TITLE
style: Dialogue

### DIFF
--- a/src/components/Dialogue/Dialogue.tsx
+++ b/src/components/Dialogue/Dialogue.tsx
@@ -5,7 +5,7 @@ import {
   useEffect,
   MouseEvent,
 } from "react";
-import { Box, Dialog as MaterialDialog, Typography } from "@mui/material";
+import { Box, Dialog as MaterialDialog } from "@mui/material";
 import { Card } from "../Card/Card";
 import { Button } from "../Button/Button";
 import { white } from "../../theme";
@@ -63,8 +63,7 @@ export function Dialogue(props: Props): ReactElement | null {
         backgroundColor={props.backgroundColor}
       >
         <>
-          <Typography>{props.children}</Typography>
-
+          {props.children}
           {props.onConfirm && (
             <Box
               sx={{

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -78,11 +78,11 @@ export const theme = createTheme({
         },
       },
     },
-
     MuiDialog: {
       styleOverrides: {
         paper: {
           borderRadius: "8px",
+          maxWidth: "unset",
         },
       },
     },


### PR DESCRIPTION
## Description
- fix: unset `maxWidth` in Material UI Dialog's Paper component, otherwise dialog cards cannot be larged than 600px.
- fix: remove unnecessary `<Topography>`

relates to https://github.com/gliff-ai/roadmap/issues/82

required by 
## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
